### PR TITLE
some polish

### DIFF
--- a/AeroGearJsonSZ/JsonSZ.swift
+++ b/AeroGearJsonSZ/JsonSZ.swift
@@ -140,11 +140,11 @@ Serialize/Deserialize to cover primitive types.
 :param: right     JsonSZ object to hold json structure.
 */
 public func <=<T>(inout left: T?, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFomPrimitiveType)
+    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFromPrimitiveType)
 }
 
 public func <=<T>(inout left: T, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFomPrimitiveType)
+    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFromPrimitiveType)
 }
 
 /**
@@ -154,11 +154,11 @@ Serialize/Deserialize to cover object types.
 :param: right     JsonSZ object to hold json structure.
 */
 public func <=<T: JSONSerializable>(inout left: T?, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToObjectType, toJsonFomObjectType)
+    conditionalFunctionCall(&left, right, fromJsonToObjectType, toJsonFromObjectType)
 }
 
 public func <=<T: JSONSerializable>(inout left: T, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToObjectType, toJsonFomObjectType)
+    conditionalFunctionCall(&left, right, fromJsonToObjectType, toJsonFromObjectType)
 }
 
 
@@ -169,11 +169,11 @@ Serialize/Deserialize to cover array types.
 :param: right     JsonSZ object to hold json structure.
 */
 public func <=<T: JSONSerializable>(inout left: [T]?, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToArrayType, toJsonFomArrayType)
+    conditionalFunctionCall(&left, right, fromJsonToArrayType, toJsonFromArrayType)
 }
 
 public func <=<T: JSONSerializable>(inout left: [T], right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToArrayType, toJsonFomArrayType)
+    conditionalFunctionCall(&left, right, fromJsonToArrayType, toJsonFromArrayType)
 }
 
 /**
@@ -183,11 +183,11 @@ Serialize/Deserialize to cover array primitive types.
 :param: right     JsonSZ object to hold json structure.
 */
 public func <=(inout left: [AnyObject]?, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFomArrayType)
+    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFromArrayType)
 }
 
 public func <=(inout left: [AnyObject], right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFomArrayType)
+    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFromArrayType)
 }
 
 /**
@@ -197,11 +197,11 @@ Serialize/Deserialize to cover array dictionary types.
 :param: right     JsonSZ object to hold json structure.
 */
 public func <=<T: JSONSerializable>(inout left: [String:  T]?, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToDictionaryType, toJsonFomDictionaryType)
+    conditionalFunctionCall(&left, right, fromJsonToDictionaryType, toJsonFromDictionaryType)
 }
 
 public func <=<T: JSONSerializable>(inout left: [String:  T], right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToDictionaryType, toJsonFomDictionaryType)
+    conditionalFunctionCall(&left, right, fromJsonToDictionaryType, toJsonFromDictionaryType)
 }
 
 /**
@@ -211,11 +211,11 @@ Serialize/Deserialize to cover array dictionary primitives.
 :param: right     JsonSZ object to hold json structure.
 */
 public func <=(inout left: [String:  AnyObject]?, right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFomDictionaryType)
+    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFromDictionaryType)
 }
 
 public func <=(inout left: [String:  AnyObject], right: JsonSZ) {
-    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFomDictionaryType)
+    conditionalFunctionCall(&left, right, fromJsonToPrimitiveType, toJsonFromDictionaryType)
 }
 
 // Mark - Utilities functions
@@ -350,7 +350,7 @@ func fromJsonToDictionaryType<N: JSONSerializable>(inout field: [String: N], val
     }
 }
 
-func toJsonFomPrimitiveType<N>(field: N?, key: String, inout dictionary: [String : AnyObject]) {
+func toJsonFromPrimitiveType<N>(field: N?, key: String, inout dictionary: [String : AnyObject]) {
     if let field: N = field {
         switch N.self {
         case is Bool.Type:
@@ -369,13 +369,13 @@ func toJsonFomPrimitiveType<N>(field: N?, key: String, inout dictionary: [String
     }
 }
 
-func toJsonFomObjectType<N: JSONSerializable>(field: N?, key: String, inout dictionary: [String : AnyObject]) {
+func toJsonFromObjectType<N: JSONSerializable>(field: N?, key: String, inout dictionary: [String : AnyObject]) {
     if let field = field {
         dictionary[key] = NSDictionary(dictionary: JsonSZ().toJSON(field))
     }
 }
 
-func toJsonFomArrayType<N: JSONSerializable>(field: [N]?, key: String, inout dictionary: [String : AnyObject]) {
+func toJsonFromArrayType<N: JSONSerializable>(field: [N]?, key: String, inout dictionary: [String : AnyObject]) {
     if let field = field {
         var objects = NSMutableArray()
         
@@ -389,13 +389,13 @@ func toJsonFomArrayType<N: JSONSerializable>(field: [N]?, key: String, inout dic
     }
 }
 
-func toJsonFomArrayType(field: [AnyObject]?, key: String, inout dictionary: [String : AnyObject]) {
+func toJsonFromArrayType(field: [AnyObject]?, key: String, inout dictionary: [String : AnyObject]) {
     if let value = field {
         dictionary[key] = NSArray(array: value)
     }
 }
 
-func toJsonFomDictionaryType<N: JSONSerializable>(field: [String: N]?, key: String, inout dictionary: [String : AnyObject]) {
+func toJsonFromDictionaryType<N: JSONSerializable>(field: [String: N]?, key: String, inout dictionary: [String : AnyObject]) {
     if let field = field {
         var objects = NSMutableDictionary()
         
@@ -409,7 +409,7 @@ func toJsonFomDictionaryType<N: JSONSerializable>(field: [String: N]?, key: Stri
     }
 }
 
-func toJsonFomDictionaryType(field: [String: AnyObject]?, key: String, inout dictionary: [String : AnyObject]) {
+func toJsonFromDictionaryType(field: [String: AnyObject]?, key: String, inout dictionary: [String : AnyObject]) {
     if let value = field {
         dictionary[key] = NSDictionary(dictionary: value)
     }

--- a/AeroGearJsonSZTests/AeroGearJsonSZTests.swift
+++ b/AeroGearJsonSZTests/AeroGearJsonSZTests.swift
@@ -33,25 +33,6 @@ class AeroGearJsonSZTests: XCTestCase {
         super.tearDown()
     }
     
-    func testJSONToObjectModelWithioutNonOptionalFirstnameShouldReturnDefaut() {
-        var contributorJSON = ["id": 100, "lastname": "Doe", "title": "Software Engineer", "age": 40, "committer": true, "weight": 60.2, "githubReposList":["foo", "bar"], "dictionary": ["foo": "bar"]]
-        
-        // serialize from json
-        let contributor:Contributor = self.serializer.fromJSON(contributorJSON, to: Contributor.self)
-        
-        // assert construction has succeeded on primitive fields
-        XCTAssertTrue(contributor.id == 100)
-        XCTAssertTrue(contributor.firstname == "Default")
-        XCTAssertTrue(contributor.lastname == "Doe")
-        XCTAssertTrue(contributor.title == "Software Engineer")
-        XCTAssertTrue(contributor.age == 40)
-        XCTAssertTrue(contributor.committer == true)
-        XCTAssertTrue(contributor.weight ==     60.2)
-        XCTAssertTrue(contributor.githubReposList?.count == 2)
-        XCTAssertTrue(contributor.dictionary?.count == 1)
-        
-    }
-    
     func testJSONToObjectModelWithPrimitiveAttributes() {
         var contributorJSON = ["id": 100, "firstname": "John", "lastname": "Doe", "title": "Software Engineer", "age": 40, "committer": true, "weight": 60.2, "githubReposList":["foo", "bar"], "dictionary": ["foo": "bar"]]
         
@@ -70,7 +51,7 @@ class AeroGearJsonSZTests: XCTestCase {
         XCTAssertTrue(contributor.dictionary?.count == 1)
         
     }
-
+    
     func testObjectModelToJSONWithPrimitiveAttributes() {
         // construct object
         let contributor = Contributor()
@@ -100,13 +81,14 @@ class AeroGearJsonSZTests: XCTestCase {
         XCTAssertTrue((json["dictionary"] as [String:String]).count == 1)
     }
     
-     func testJSONToObjectModelWithPrimitiveAttributesAndMissingValues() {
+    func testJSONToObjectModelWithPrimitiveAttributesAndMissingValues() {
         var contributorJSON = ["id": 100, "title":  "Software Engineer"]
         // serialize from json
         let contributor:Contributor = self.serializer.fromJSON(contributorJSON, to: Contributor.self)
         
         // assert construction has succeeded and missing values are nil
         XCTAssertTrue(contributor.id == 100)
+        XCTAssertTrue(contributor.firstname == nil)
         XCTAssertTrue(contributor.lastname == nil)
         XCTAssertTrue(contributor.title == "Software Engineer")
         XCTAssertTrue(contributor.age == nil)
@@ -125,6 +107,7 @@ class AeroGearJsonSZTests: XCTestCase {
         
         // assert json dictionary has been populated
         XCTAssertTrue(json["id"] as? Int == 100)
+        XCTAssertTrue(json["firstname"] == nil)
         XCTAssertTrue(json["lastname"] == nil)
         XCTAssertTrue(json["title"] as? String == "Software Engineer")
         XCTAssertTrue(json["age"]  == nil)
@@ -163,7 +146,7 @@ class AeroGearJsonSZTests: XCTestCase {
         
         // serialize to json
         let json = self.serializer.toJSON(contributor)
-
+        
         // assert construction has succeeded
         XCTAssertTrue(json["firstname"] as String == "John")
         // asssert relationship has succeeded
@@ -175,7 +158,7 @@ class AeroGearJsonSZTests: XCTestCase {
     }
     
     func testOneToManyRelationshipFromJSON() {
-       // construct objects
+        // construct objects
         var contributorAJSON = ["id": 100, "firstname": "John"]
         var contributorBJSON = ["id": 101, "firstname": "Maria"]
         
@@ -221,11 +204,11 @@ class AeroGearJsonSZTests: XCTestCase {
         XCTAssertTrue(json["name"] as String == "AeroGear")
         // asssert relationship has succeeded
         let contributorsJSON = json["contributors"] as [[String: AnyObject]]
-
+        
         let contributorAJSON = contributorsJSON[0] as [String: AnyObject]
         XCTAssertTrue(contributorAJSON["id"] as Int == 100)
         XCTAssertTrue(contributorAJSON["firstname"] as String == "John")
-
+        
         let contributorBJSON = contributorsJSON[1] as [String: AnyObject]
         XCTAssertTrue(contributorBJSON["id"] as Int == 101)
         XCTAssertTrue(contributorBJSON["firstname"] as String == "Maria")
@@ -236,10 +219,57 @@ class AeroGearJsonSZTests: XCTestCase {
         let arrayJSONString = "[{\"firstname\": \"Elisa\", \"id\": \"2\", \"age\": 54},{ \"firstname\": \"Mireille\", \"id\": \"3\", \"age\": 25,}]"
         
         let studentArray: [Contributor!]? = self.serializer.fromJSONArray(arrayJSONString, to: Contributor.self)
-
+        
         XCTAssert(studentArray?.count == 2, "There should be 2 students in array")
         XCTAssert(studentArray?[0].firstname == "Elisa", "First student's does not match")
         XCTAssert(studentArray?[1].firstname == "Mireille", "Second student's does not match")
-
+        
     }
+    
+    func testJSONToObjectModelWithPrimitiveAttributesWithoutOptionals() {
+        var developerJSON = ["id": 100, "firstname": "John", "lastname": "Doe", "title": "Software Engineer", "age": 40, "committer": true, "weight": 60.2, "githubReposList":["foo", "bar"], "dictionary": ["foo": "bar"]]
+        
+        // serialize from json
+        let developer:Developer = self.serializer.fromJSON(developerJSON, to: Developer.self)
+        
+        // assert construction has succeeded on primitive fields
+        XCTAssertTrue(developer.id == 100)
+        XCTAssertTrue(developer.firstname == "John")
+        XCTAssertTrue(developer.lastname == "Doe")
+        XCTAssertTrue(developer.title == "Software Engineer")
+        XCTAssertTrue(developer.age == 40)
+        XCTAssertTrue(developer.committer == true)
+        XCTAssertTrue(developer.weight ==     60.2)
+        XCTAssertTrue(developer.githubReposList.count == 2)
+        XCTAssertTrue(developer.dictionary.count == 1)
+    }
+    
+    func testObjectModelToJSONWithPrimitiveAttributesWithoutOptionals() {
+        // construct object
+        let developer = Developer()
+        developer.id = 100
+        developer.firstname = "John"
+        developer.lastname = "Doe"
+        developer.title = "Software Engineer"
+        developer.age = 40
+        developer.committer = true
+        developer.weight = 60.2
+        developer.githubReposList = ["foo", "bar"]
+        developer.dictionary = ["foo": "bar"]
+        
+        // serialize to json
+        let json = self.serializer.toJSON(developer)
+        
+        // assert json dictionary has been populated
+        XCTAssertTrue(json["id"] as Int == 100)
+        XCTAssertTrue(json["firstname"] as String == "John")
+        XCTAssertTrue(json["lastname"] as String == "Doe")
+        XCTAssertTrue(json["title"] as String == "Software Engineer")
+        XCTAssertTrue(json["age"] as Double == 40)
+        XCTAssertTrue(json["committer"] as Bool == true)
+        XCTAssertTrue(json["weight"] as Float == 60.2)
+        XCTAssertTrue((json["githubReposList"] as [String]).count == 2)
+        XCTAssertTrue((json["githubReposList"] as [String]).count == 2)
+        XCTAssertTrue((json["dictionary"] as [String:String]).count == 1)
+    }    
 }

--- a/AeroGearJsonSZTests/Model/Model.swift
+++ b/AeroGearJsonSZTests/Model/Model.swift
@@ -18,8 +18,8 @@
 import AeroGearJsonSZ
 
 class Address: JSONSerializable {
-
-    var street: String = ""
+    
+    var street: String?
     var poBox: Int?
     var city: String?
     var country: String?
@@ -37,7 +37,7 @@ class Address: JSONSerializable {
 class Contributor: JSONSerializable {
     
     var id: Int?
-    var firstname: String = "Default"
+    var firstname: String?
     var lastname: String?
     var title: String?
     var age: Double?
@@ -73,5 +73,48 @@ class Team: JSONSerializable {
     class func map(source: JsonSZ, object: Team) {
         object.name <= source["name"]
         object.contributors <= source["contributors"]
+    }
+}
+
+
+class Developer: JSONSerializable {
+    var id: Int
+    var firstname: String
+    var lastname: String
+    var title: String
+    var age: Double
+    var committer: Bool
+    var weight: Float
+    var githubReposList:[AnyObject]
+    var dictionary:[String: AnyObject]
+    
+    var address: Address
+    
+    required init() {
+        // put some defaults to satisfy swift object construction (not used)
+        id = 0
+        firstname = ""
+        lastname = ""
+        title = ""
+        age = 0
+        committer = false
+        weight = 0
+        githubReposList = ["null", "null"]
+        dictionary = ["null" : "null"]
+        let addr = Address()
+        address = addr
+    }
+    
+    class func map(source: JsonSZ, object: Developer) {
+        object.id <= source["id"]
+        object.firstname <= source["firstname"]
+        object.lastname <= source["lastname"]
+        object.title <= source["title"]
+        object.age <= source["age"]
+        object.committer <= source["committer"]
+        object.weight <= source["weight"]
+        object.githubReposList <= source["githubReposList"]
+        object.dictionary <= source["dictionary"]
+        object.address <= source["address"]
     }
 }


### PR DESCRIPTION
@corinnekrych added an non-optional object 'Developer' (a clone of the Contributor object) just to test all cases of non-optionals.

I bumped out in one test case that fails, that is is the call of the toJSON when serializing a dictionary and in particular [this line](https://github.com/cvasilak/aerogear-ios-jsonsz/blob/optionals.support/AeroGearJsonSZTests/AeroGearJsonSZTests.swift#L258).

I pinpointed the error [in this method](https://github.com/cvasilak/aerogear-ios-jsonsz/blob/optionals.support/AeroGearJsonSZ/JsonSZ.swift#L413). For some reason, when trying to access the 'key' field I get a "EXEC_BAD_ACCESS"

Haven't  found why, but will look later tonight or in the morning with clean head. Feel free to merge this PR if you think so (contains some typo in method name and the added non-optional model) and work from here and we can discuss together
